### PR TITLE
Changes for readr 2.0.0

### DIFF
--- a/R/get_data.R
+++ b/R/get_data.R
@@ -42,7 +42,7 @@ tryCatch(
 
     text <- httr::content(data, as = "text")
 
-    data <- readr::read_csv(text)
+    data <- readr::read_csv(I(text))
 
     names(data) <- gsub(".", "_", names(data), fixed = TRUE)
 

--- a/tests/testthat/test-test_get_data.R
+++ b/tests/testthat/test-test_get_data.R
@@ -8,16 +8,16 @@ data <- httr::RETRY(
 
 text <- httr::content(data, as = "text")
 
-data <- readr::read_csv(text)
+data <- readr::read_csv(I(text))
 
 names(data) <- gsub(".", "_", names(data), fixed = TRUE)
 
 final <- data
 
 
-test_that("testing identical results", {
+test_that("testing equal results", {
 
-  testthat::expect_identical(final,get_data(n = 10, seed = "123"))
+  testthat::expect_equal(final,get_data(n = 10, seed = "123"))
 
   testthat::expect_s3_class(final, "data.frame")
 


### PR DESCRIPTION
In previous version of readr the reading functions took literal data as any
filename with a newline in it or vectors of length > 1. In readr 2.0.0 vectors
of length > 1 are now  assumed to correspond to multiple files. Because of this
we now use a more explicit way to represent literal data, by using the `I()`
function around the input.

In addition the way that the problems attribute is stored has changed
and is now an external pointer. Because of this, two datasets will never
be identical, so one test needed to be changed to expect_equal instead.

We plan to submit readr 2.0.0 to CRAN in 2-4 weeks, you will need to submit this change as well to avoid breaking tests once readr 2.0.0 is accepted.